### PR TITLE
Move @types from devDeps to dependencies, add types entry point, silence travis emails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,6 @@ script:
 
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+
+notifications:
+  email: false

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "precommit": "precise-commits"
   },
   "dependencies": {
+    "@types/lodash.clonedeep": "^4.5.3",
+    "@types/lodash.isequal": "^4.5.2",
+    "@types/lodash.set": "^4.3.3",
+    "@types/lodash.unset": "^4.5.3",
     "lodash.clonedeep": "^4.5.0",
     "lodash.isequal": "^4.5.0",
     "lodash.set": "^4.3.2",
@@ -20,10 +24,6 @@
   },
   "devDependencies": {
     "@types/jest": "^22.2.3",
-    "@types/lodash.clonedeep": "^4.5.3",
-    "@types/lodash.isequal": "^4.5.2",
-    "@types/lodash.set": "^4.3.3",
-    "@types/lodash.unset": "^4.5.3",
     "babel-eslint": "^7.2.3",
     "eslint": "^4.1.1",
     "eslint-config-react-app": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description":
     "Higher order functions for creating opinionated redux reducers, selectors, actions, and action creators",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "author": "Malcolm Ahoy <malcolmahoy@gmail.com>",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## Context
`@types/*` need to be moved from `devDependencies` to `dependencies`. We also need to set an entry point for the type definitions (not built yet though), and plz travis don't send emails


## Tasks

* [n/a] Unit tests added
