### PR TITLE
Make create reducer

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,10 @@
       "\\.(ts|tsx)$": "ts-jest"
     },
     "testRegex": "/src/.*\\.spec.(ts)$",
-    "collectCoverage": true
+    "collectCoverage": true,
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "/src/reducer-factories/test-utils/"
+    ]
   }
 }

--- a/src/reducer-factories/create-cycle/make-create-reducer.spec.ts
+++ b/src/reducer-factories/create-cycle/make-create-reducer.spec.ts
@@ -1,0 +1,66 @@
+import makeCreateReducer from './make-create-reducer';
+
+import {
+  assertOutputIsFunction,
+  assertInitialStateReturnedOnInit,
+  assertStateReturnedOnInvalidActionType,
+  assertErrorsSet,
+} from './../test-utils/common-specs';
+import { API_ACTION_PREFIXES, API_LIFECYCLE_SUFFIXES } from '../../actions';
+
+const { CREATE } = API_ACTION_PREFIXES;
+const { ERROR, SUCCESS } = API_LIFECYCLE_SUFFIXES;
+const FETCH_RESOURCE_ERROR = `${CREATE}_*_${ERROR}`;
+const FETCH_RESOURCE_SUCCESS = `${CREATE}_*_${SUCCESS}`;
+
+describe('makeCreateReducer()', () => {
+  const entitiesPath = 'byId';
+  const defaultProps = { entitiesPath };
+
+  assertOutputIsFunction(() => makeCreateReducer(defaultProps));
+  assertInitialStateReturnedOnInit(() => makeCreateReducer(defaultProps));
+  assertStateReturnedOnInvalidActionType(
+    () => makeCreateReducer(defaultProps),
+    CREATE
+  );
+
+  it(`sets errors at the state slice root on the *_ERROR action.type`, () => {
+    const reducer = makeCreateReducer(defaultProps);
+    const mockState = {};
+    const initialState = reducer(mockState, { type: '@@INIT' });
+    expect(initialState).toEqual(mockState);
+
+    const failureAction = {
+      type: FETCH_RESOURCE_ERROR,
+      errors: ['something went wrong!'],
+    };
+    const nextState = reducer(mockState, failureAction);
+
+    expect(nextState).toHaveProperty('errors');
+  });
+
+  describe('outcomes with the *_SUCCESS action.type', () => {
+    it('unsets the root errors and sets the payload to the payload.id', () => {
+      const reducer = makeCreateReducer(defaultProps);
+      const initialState = {
+        errors: ['Some error while creating'],
+        [entitiesPath]: {
+          '123': { id: '123', name: 'foo' },
+        },
+      };
+      const successAction = {
+        type: FETCH_RESOURCE_SUCCESS,
+        payload: {
+          id: '456',
+          name: 'bar',
+        },
+      };
+      const nextState = reducer(initialState, successAction);
+
+      // Check existing entity is still present
+      expect(nextState[entitiesPath]).toHaveProperty('123');
+      expect(nextState[entitiesPath]).toHaveProperty(successAction.payload.id);
+      expect(nextState).not.toHaveProperty('errors');
+    });
+  });
+});

--- a/src/reducer-factories/create-cycle/make-create-reducer.spec.ts
+++ b/src/reducer-factories/create-cycle/make-create-reducer.spec.ts
@@ -4,7 +4,6 @@ import {
   assertOutputIsFunction,
   assertInitialStateReturnedOnInit,
   assertStateReturnedOnInvalidActionType,
-  assertErrorsSet,
 } from './../test-utils/common-specs';
 import { API_ACTION_PREFIXES, API_LIFECYCLE_SUFFIXES } from '../../actions';
 

--- a/src/reducer-factories/create-cycle/make-create-reducer.ts
+++ b/src/reducer-factories/create-cycle/make-create-reducer.ts
@@ -1,0 +1,37 @@
+import cloneDeep from 'lodash.clonedeep';
+import set from 'lodash.set';
+import unset from 'lodash.unset';
+
+import { ReducerConfig, ReduxSliceState } from './../type-definitions';
+import {
+  Action,
+  API_ACTION_PREFIXES,
+  API_LIFECYCLE_SUFFIXES,
+  isValidActionType,
+} from '../../actions';
+
+function makeCreateReducer({ entitiesPath }: ReducerConfig): Function {
+  return (state: ReduxSliceState, action: Action): ReduxSliceState => {
+    const { type, payload, errors } = action;
+
+    if (!isValidActionType(API_ACTION_PREFIXES.CREATE, type)) return state;
+
+    const nextState = cloneDeep(state);
+
+    if (type.endsWith(API_LIFECYCLE_SUFFIXES.ERROR)) {
+      return set(nextState, 'errors', errors);
+    }
+
+    if (type.endsWith(API_LIFECYCLE_SUFFIXES.SUCCESS)) {
+      const referenceId: string = payload.id.toString();
+      const attributePath: string[] = [entitiesPath, referenceId];
+
+      unset(nextState, 'errors');
+      return set(nextState, attributePath, payload);
+    }
+
+    return state;
+  };
+}
+
+export default makeCreateReducer;


### PR DESCRIPTION
## Context

Adds the `makeCreateReducer` factory for usage in the `defaultReducerFactories`. Specifically handles only single entity additions (no batch creates, should make a separate reducer for these cases for clarity), sets errors to the errors property on the state slice root, and does **not** include a pending state by default.

This is because we recommend visualizing the redux store as a front end version of your database, as much as possible. Maintaining CREATE data structures that haven't been persisted to the data base yet violates that philosophy, and there are various strategies to handle that type of state. Some suggestions:
- Can use local component state
- Can create separate reducers (non-`redesert` generated) for specific UI state
    - eg, `redux-form` essentially creates a redux state slice specifically per instantiated form
- Can create a separate namespace under each state slice specifically for non persisted data

## Additional Changes
- Ignore `test-utils` from coverage

## Tasks

* [x] Unit tests added
