### PR TITLE
Make "remove" reducer factory

### DIFF
--- a/src/reducer-factories/fetch-cycle/make-fetch-reducer.spec.ts
+++ b/src/reducer-factories/fetch-cycle/make-fetch-reducer.spec.ts
@@ -38,7 +38,8 @@ describe('makeFetchLifeCycle()', () => {
   assertErrorsSet(
     (testEntitiesPath: string) =>
       makeFetchLifeCycle({ ...defaultProps, entitiesPath: testEntitiesPath }),
-    FETCH_RESOURCE_ERROR
+    FETCH_RESOURCE_ERROR,
+    'isFetching'
   );
 
   describe('outcomes with the *_SUCCESS action.type', () => {

--- a/src/reducer-factories/remove-cycle/remove-reducer.spec.ts
+++ b/src/reducer-factories/remove-cycle/remove-reducer.spec.ts
@@ -1,0 +1,79 @@
+import removeReducerFactory from './remove-reducer';
+import { API_ACTION_PREFIXES, API_LIFECYCLE_SUFFIXES } from '../../actions';
+import {
+  assertOutputIsFunction,
+  assertInitialStateReturnedOnInit,
+  assertStateReturnedOnInvalidActionType,
+  assertPendingStateSet,
+  assertErrorsSet,
+} from './../test-utils/common-specs';
+
+const { START, ERROR, SUCCESS } = API_LIFECYCLE_SUFFIXES;
+const { REMOVE } = API_ACTION_PREFIXES;
+const REMOVE_RESOURCE_START = `${REMOVE}_*_${START}`;
+const REMOVE_RESOURCE_ERROR = `${REMOVE}_*_${ERROR}`;
+const REMOVE_RESOURCE_SUCCESS = `${REMOVE}_*_${SUCCESS}`;
+
+describe('removeReducerFactory()', () => {
+  const entitiesPath = 'byId';
+  const defaultProps = { entitiesPath };
+
+  assertOutputIsFunction(() => removeReducerFactory(defaultProps));
+
+  assertInitialStateReturnedOnInit(() => removeReducerFactory(defaultProps));
+
+  assertStateReturnedOnInvalidActionType(
+    () => removeReducerFactory(defaultProps),
+    REMOVE
+  );
+
+  assertPendingStateSet(
+    () => removeReducerFactory(defaultProps),
+    REMOVE_RESOURCE_START,
+    'isRemoving'
+  );
+
+  assertErrorsSet(
+    () => removeReducerFactory(defaultProps),
+    REMOVE_RESOURCE_ERROR,
+    'isRemoving'
+  );
+
+  it('throws an error if a valid REMOVE action, but no meta.referenceId', () => {
+    const invalidAction = {
+      type: REMOVE_RESOURCE_START,
+      // no meta.referenceId
+    };
+    const reducer = removeReducerFactory(defaultProps);
+
+    expect(() => reducer({}, invalidAction)).toThrow();
+  });
+
+  describe('outcomes with the *_SUCCESS action.type', () => {
+    it('deletes the entity at the meta.referenceId', () => {
+      const referenceId = '123';
+      const successAction = {
+        type: REMOVE_RESOURCE_SUCCESS,
+        meta: { referenceId },
+      };
+      const initialState = {
+        [entitiesPath]: {
+          [referenceId]: {
+            id: referenceId,
+            name: 'foo',
+          },
+          '234': {
+            id: '234',
+            name: 'bar',
+          },
+        },
+      };
+      const reducer = removeReducerFactory(defaultProps);
+      const nextState = reducer(initialState, successAction);
+
+      // Assert an existing entity isn't removed as well
+      expect(nextState[entitiesPath]).toHaveProperty('234');
+      expect(nextState[entitiesPath]).not.toHaveProperty(referenceId);
+    });
+  });
+});

--- a/src/reducer-factories/remove-cycle/remove-reducer.ts
+++ b/src/reducer-factories/remove-cycle/remove-reducer.ts
@@ -1,0 +1,51 @@
+import cloneDeep from 'lodash.clonedeep';
+import set from 'lodash.set';
+import unset from 'lodash.unset';
+
+import { ReducerConfig, ReduxSliceState } from './../type-definitions';
+import {
+  Action,
+  isValidActionType,
+  API_ACTION_PREFIXES,
+  API_LIFECYCLE_SUFFIXES,
+} from '../../actions';
+
+function removeReducerFactory({ entitiesPath }: ReducerConfig): Function {
+  return (state: ReduxSliceState, action: Action): ReduxSliceState => {
+    const { type, payload, errors, meta } = action;
+
+    if (!isValidActionType(API_ACTION_PREFIXES.REMOVE, type)) return state;
+    const newState = cloneDeep(state);
+    const referenceId =
+      meta && meta.referenceId ? meta.referenceId.toString() : null;
+
+    if (referenceId === null) {
+      throw new Error(`A ${API_ACTION_PREFIXES.REMOVE} action type was called
+        without a meta.referenceId. It is a required attribute to determine
+        which entity to remove.
+
+        Current @meta value passed: ${meta}
+      `);
+    }
+
+    const attributesPath = [entitiesPath, referenceId];
+
+    if (type.endsWith(API_LIFECYCLE_SUFFIXES.START)) {
+      return set(newState, [...attributesPath, 'isRemoving'], true);
+    }
+
+    if (type.endsWith(API_LIFECYCLE_SUFFIXES.ERROR)) {
+      set(newState, [...attributesPath, 'isRemoving'], false);
+      return set(newState, [...attributesPath, 'errors'], errors);
+    }
+
+    if (type.endsWith(API_LIFECYCLE_SUFFIXES.SUCCESS)) {
+      unset(newState, attributesPath);
+      return newState;
+    }
+
+    return state;
+  };
+}
+
+export default removeReducerFactory;

--- a/src/reducer-factories/remove-cycle/remove-reducer.ts
+++ b/src/reducer-factories/remove-cycle/remove-reducer.ts
@@ -12,7 +12,7 @@ import {
 
 function removeReducerFactory({ entitiesPath }: ReducerConfig): Function {
   return (state: ReduxSliceState, action: Action): ReduxSliceState => {
-    const { type, payload, errors, meta } = action;
+    const { type, errors, meta } = action;
 
     if (!isValidActionType(API_ACTION_PREFIXES.REMOVE, type)) return state;
     const newState = cloneDeep(state);

--- a/src/reducer-factories/test-utils/common-specs.ts
+++ b/src/reducer-factories/test-utils/common-specs.ts
@@ -67,7 +67,11 @@ export const assertPendingStateSet = (
   });
 };
 
-export const assertErrorsSet = (output: Function, actionType: string) => {
+export const assertErrorsSet = (
+  output: Function,
+  actionType: string,
+  pendingState: string
+) => {
   it(`sets errors on the *_ERROR action.type`, () => {
     const reducer = output(testEntitiesPath);
     const initialState = reducer(mockState(), { type: '@@INIT' });
@@ -81,7 +85,7 @@ export const assertErrorsSet = (output: Function, actionType: string) => {
     const nextState = reducer(mockState(), failureAction);
     const testEntity = nextState[testEntitiesPath][referenceId];
 
-    expect(testEntity.isFetching).toEqual(false);
+    expect(testEntity[pendingState]).toEqual(false);
     expect(testEntity).toHaveProperty('errors');
   });
 };


### PR DESCRIPTION
## Context
Add a factory for a reducer that deals with remove cases, for a single entity (out of multiple entities) only. Batch removals should be handled in a separate reducer for distinct clarity. 

## Additional Changes
- Make the pending status attribute check in `assertErrorsSet` dynamic instead of hardcoded to `isFetching`

## Tasks

* [x] Unit tests added
