### PR TITLE
Add update reducer factory and specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,11 +15,15 @@
   },
   "dependencies": {
     "@types/lodash.clonedeep": "^4.5.3",
+    "@types/lodash.get": "^4.4.3",
     "@types/lodash.isequal": "^4.5.2",
+    "@types/lodash.merge": "^4.6.3",
     "@types/lodash.set": "^4.3.3",
     "@types/lodash.unset": "^4.5.3",
     "lodash.clonedeep": "^4.5.0",
+    "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.5.0",
+    "lodash.merge": "^4.6.1",
     "lodash.set": "^4.3.2",
     "lodash.unset": "^4.5.2"
   },

--- a/src/reducer-factories/update-cycle/update-reducer.spec.ts
+++ b/src/reducer-factories/update-cycle/update-reducer.spec.ts
@@ -1,0 +1,82 @@
+import {
+  assertOutputIsFunction,
+  assertInitialStateReturnedOnInit,
+  assertStateReturnedOnInvalidActionType,
+  assertPendingStateSet,
+  assertErrorsSet,
+} from './../test-utils/common-specs';
+import updateReducerFactory from './update-reducer';
+import { API_LIFECYCLE_SUFFIXES, API_ACTION_PREFIXES } from '../../actions';
+
+const { START, ERROR, SUCCESS } = API_LIFECYCLE_SUFFIXES;
+const { UPDATE } = API_ACTION_PREFIXES;
+const UPDATE_RESOURCE_START = `${UPDATE}_*_${START}`;
+const UPDATE_RESOURCE_ERROR = `${UPDATE}_*_${ERROR}`;
+const UPDATE_RESOURCE_SUCCESS = `${UPDATE}_*_${SUCCESS}`;
+
+describe('updateReducerFactory()', () => {
+  const entitiesPath = 'byId';
+  const defaultProps = { entitiesPath };
+
+  assertOutputIsFunction(() => updateReducerFactory(defaultProps));
+
+  assertInitialStateReturnedOnInit(() => updateReducerFactory(defaultProps));
+
+  assertStateReturnedOnInvalidActionType(
+    () => updateReducerFactory(defaultProps),
+    UPDATE
+  );
+
+  assertPendingStateSet(
+    () => updateReducerFactory(defaultProps),
+    UPDATE_RESOURCE_START,
+    'isUpdating'
+  );
+
+  assertErrorsSet(
+    () => updateReducerFactory(defaultProps),
+    UPDATE_RESOURCE_ERROR,
+    'isUpdating'
+  );
+
+  it('throws an error if a valid REMOVE action, but no meta.referenceId', () => {
+    const invalidAction = {
+      type: UPDATE_RESOURCE_START,
+      // no meta.referenceId
+    };
+    const reducer = updateReducerFactory(defaultProps);
+
+    expect(() => reducer({}, invalidAction)).toThrow();
+  });
+
+  describe('outcomes with the *_SUCCESS action.type', () => {
+    it('updates the entity at the meta.referenceId', () => {
+      const referenceId = '123';
+      const initialState = {
+        [entitiesPath]: {
+          [referenceId]: {
+            id: referenceId,
+            name: 'foo',
+          },
+        },
+      };
+      const successAction = {
+        type: UPDATE_RESOURCE_SUCCESS,
+        payload: {
+          id: referenceId,
+          anotherAttr: 'bar',
+        },
+        meta: { referenceId },
+      };
+      const reducer = updateReducerFactory(defaultProps);
+      const nextState = reducer(initialState, successAction);
+      const resultEntity = nextState[entitiesPath][referenceId];
+
+      expect(resultEntity).toEqual({
+        ...initialState[entitiesPath][referenceId],
+        ...successAction.payload,
+        isUpdating: false, // Added after API cycle finishes
+      });
+    });
+  });
+});

--- a/src/reducer-factories/update-cycle/update-reducer.ts
+++ b/src/reducer-factories/update-cycle/update-reducer.ts
@@ -1,0 +1,56 @@
+import cloneDeep from 'lodash.clonedeep';
+import get from 'lodash.get';
+import merge from 'lodash.merge';
+import set from 'lodash.set';
+import unset from 'lodash.unset';
+
+import { Action } from './../../actions/type-definitions';
+import { ReducerConfig, ReduxSliceState } from './../type-definitions';
+import {
+  isValidActionType,
+  API_ACTION_PREFIXES,
+  API_LIFECYCLE_SUFFIXES,
+} from '../../actions';
+
+function updateReducerFactory({ entitiesPath }: ReducerConfig): Function {
+  return (state: ReduxSliceState, action: Action): ReduxSliceState => {
+    const { type, payload, errors, meta } = action;
+
+    if (!isValidActionType(API_ACTION_PREFIXES.UPDATE, type)) return state;
+
+    const nextState = cloneDeep(state);
+    const referenceId =
+      meta && meta.referenceId ? meta.referenceId.toString() : null;
+
+    if (referenceId === null) {
+      throw new Error(`A ${API_ACTION_PREFIXES.UPDATE} action type was called
+        without a meta.referenceId. It is a required attribute to determine
+        which entity to update.
+
+        Current @meta value passed: ${meta}
+      `);
+    }
+    const attributesPath = [entitiesPath, referenceId];
+
+    if (type.endsWith(API_LIFECYCLE_SUFFIXES.START)) {
+      return set(nextState, [...attributesPath, 'isUpdating'], true);
+    }
+
+    if (type.endsWith(API_LIFECYCLE_SUFFIXES.ERROR)) {
+      set(nextState, [...attributesPath, 'isUpdating'], false);
+      return set(nextState, [...attributesPath, 'errors'], errors);
+    }
+
+    if (type.endsWith(API_LIFECYCLE_SUFFIXES.SUCCESS)) {
+      set(nextState, [...attributesPath, 'isUpdating'], false);
+      unset(nextState, [...attributesPath, 'errors']);
+      merge(get(nextState, attributesPath), payload);
+
+      return nextState;
+    }
+
+    return state;
+  };
+}
+
+export default updateReducerFactory;

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,9 +26,21 @@
   dependencies:
     "@types/lodash" "*"
 
+"@types/lodash.get@^4.4.3":
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/@types/lodash.get/-/lodash.get-4.4.3.tgz#ac823d175a9593c10555b5097b72281effd544b5"
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash.isequal@^4.5.2":
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/@types/lodash.isequal/-/lodash.isequal-4.5.2.tgz#adbdff67f7c956ed703009e5466a34eeddb0b712"
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash.merge@^4.6.3":
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/@types/lodash.merge/-/lodash.merge-4.6.3.tgz#a41c49fe404c4bfb653ae6dda76abeedeace14ff"
   dependencies:
     "@types/lodash" "*"
 
@@ -2492,9 +2504,17 @@ lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+
+lodash.merge@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
 
 lodash.set@^4.3.2:
   version "4.3.2"


### PR DESCRIPTION
## Context
Add a reducer factory that handles updates for single entities. Batch updates should be done in a separate reducer for clarity and to not convolute logic in a single reducer.

## Additional Changes
- Adds `lodash.get` for deep getting
- Adds `lodash.merge` for deep merging

## Tasks

* [x] Unit tests added
