### PR TITLE
Make selector factories

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
       "\\.(ts|tsx)$": "ts-jest"
     },
     "testRegex": "/src/.*\\.spec.(ts)$",
-    "collectCoverage": true,
     "coveragePathIgnorePatterns": [
       "/node_modules/",
       "/src/reducer-factories/test-utils/"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@types/jest": "^22.2.3",
+    "@types/reselect": "^2.2.0",
     "babel-eslint": "^7.2.3",
     "eslint": "^4.1.1",
     "eslint-config-react-app": "^2.1.0",
@@ -45,6 +46,7 @@
     "jest": "^22.4.3",
     "precise-commits": "^1.0.2",
     "prettier": "^1.12.1",
+    "reselect": "^3.0.1",
     "ts-jest": "^22.4.5",
     "typescript": "^2.8.3",
     "typescript-eslint-parser": "^15.0.0"

--- a/package.json
+++ b/package.json
@@ -14,12 +14,16 @@
     "precommit": "precise-commits"
   },
   "dependencies": {
+    "@types/lodash.camelcase": "^4.3.3",
+    "@types/lodash.capitalize": "^4.2.3",
     "@types/lodash.clonedeep": "^4.5.3",
     "@types/lodash.get": "^4.4.3",
     "@types/lodash.isequal": "^4.5.2",
     "@types/lodash.merge": "^4.6.3",
     "@types/lodash.set": "^4.3.3",
     "@types/lodash.unset": "^4.5.3",
+    "lodash.camelcase": "^4.3.0",
+    "lodash.capitalize": "^4.2.1",
     "lodash.clonedeep": "^4.5.0",
     "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.5.0",
@@ -55,5 +59,9 @@
       "/node_modules/",
       "/src/reducer-factories/test-utils/"
     ]
+  },
+  "peerDependencies": {
+    "@types/reselect": "^2.2.0",
+    "reselect": "^3.0.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,31 @@
-import resourceReducerFactory from './reducer-factories/resource-reducer-factory';
 import defaultReducerFactories from './reducer-factories/default-factories';
+import resourceReducerFactory from './reducer-factories/resource-reducer-factory';
+import selectorsFactory from './selector-factories/base-selectors';
 import { DefaultReducerFactories } from './reducer-factories/type-definitions';
 
 const entitiesPath = 'byId';
 
-type Config = {
+type MakeResourceReducerConfig = {
   entitiesPath: string;
   initialState?: any;
   defaultReducerFactories?: DefaultReducerFactories;
   resource: string;
 };
 
-export const makeResourceReducer = (config: Config): Function =>
+export const makeResourceReducer = (
+  config: MakeResourceReducerConfig
+): Function =>
   resourceReducerFactory({
     defaultReducerFactories,
     entitiesPath,
     ...config,
   });
 
-export { resourceReducerFactory };
+type MakeResourceSelectorsConfig = {
+  entitiesPath: string;
+  resource: string;
+};
+export const makeResourceSelectors = (config: MakeResourceSelectorsConfig) =>
+  selectorsFactory({ entitiesPath, ...config });
+
+export { resourceReducerFactory, selectorsFactory };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,21 @@
 import resourceReducerFactory from './reducer-factories/resource-reducer-factory';
 import defaultReducerFactories from './reducer-factories/default-factories';
-import { MakeReducerConfiguration } from './reducer-factories/type-definitions';
+import { DefaultReducerFactories } from './reducer-factories/type-definitions';
 
 const entitiesPath = 'byId';
 
-export const makeResourceReducer = (
-  config: MakeReducerConfiguration
-): Function =>
-  resourceReducerFactory({ defaultReducerFactories, entitiesPath, ...config });
+type Config = {
+  entitiesPath: string;
+  initialState?: any;
+  defaultReducerFactories?: DefaultReducerFactories;
+  resource: string;
+};
+
+export const makeResourceReducer = (config: Config): Function =>
+  resourceReducerFactory({
+    defaultReducerFactories,
+    entitiesPath,
+    ...config,
+  });
 
 export { resourceReducerFactory };

--- a/src/selector-factories/base-selectors.spec.ts
+++ b/src/selector-factories/base-selectors.spec.ts
@@ -1,0 +1,141 @@
+import selectorsFactory from './base-selectors';
+import { makeResourceReducer } from './../index';
+import { API_ACTION_PREFIXES, API_LIFECYCLE_SUFFIXES } from '../actions';
+
+const { FETCH, UPDATE, REMOVE } = API_ACTION_PREFIXES;
+const { START, FAILURE } = API_LIFECYCLE_SUFFIXES;
+
+describe('selectorsFactory()', () => {
+  const entitiesPath = 'byId';
+  const resource = 'foo';
+  const id = '789';
+  const initialState = {
+    [entitiesPath]: {
+      '123': { id: '123', name: 'foo' },
+      '456': { id: '456', name: 'bar' },
+      [id]: { id, name: 'baz' },
+    },
+  };
+  const fooReducer = makeResourceReducer({
+    entitiesPath,
+    initialState,
+    resource,
+  });
+  const callFooReducer = (action: object, customState = undefined) => {
+    const nextState = {
+      [resource]: fooReducer(customState, action),
+    };
+    return nextState;
+  };
+  const fooSelectors = selectorsFactory({ entitiesPath, resource });
+
+  it('dynamically creates a base set of selectors', () => {
+    [
+      `getFooEntities`,
+      `getFooById`,
+      `getCurrentFoo`,
+      `getFooErrors`,
+      `getFooErrorsById`,
+      `getAreFooEntitiesFetching`,
+      `getIsFooFetching`,
+      `getIsFooUpdating`,
+      `getIsFooRemoving`,
+    ].forEach(selectorName => {
+      expect(fooSelectors).toHaveProperty(selectorName);
+    });
+  });
+
+  it('gets all entities with get*Entities()', () => {
+    const state = callFooReducer({ type: '@@INIT' });
+
+    expect(fooSelectors.getFooEntities(state)).toEqual(
+      initialState[entitiesPath]
+    );
+  });
+
+  it('gets a specific entity with get*EntityById', () => {
+    const state = callFooReducer({ type: '@@INIT' });
+    expect(fooSelectors.getFooById(state, { id })).toEqual(
+      initialState[entitiesPath][id]
+    );
+  });
+
+  it('gets the first entity with getCurrent*', () => {
+    const state = callFooReducer({ type: '@@INIT' });
+    expect(fooSelectors.getCurrentFoo(state)).toEqual(
+      initialState[entitiesPath]['123']
+    );
+  });
+
+  it('gets root level errors with get*Errors', () => {
+    const errors = ['nooooo root level error'];
+    // Only action type that can set root level errors
+    const errorAction = {
+      type: `${FETCH}_${resource}_${FAILURE}`,
+      errors,
+    };
+    const state = callFooReducer(errorAction);
+
+    expect(fooSelectors.getFooErrors(state)).toEqual(errors);
+  });
+
+  it('gets specific errors with get*ErrorsById', () => {
+    const errors = ['error at entity'];
+    const errorAction = {
+      type: `${FETCH}_${resource}_${FAILURE}`,
+      errors,
+      meta: {
+        referenceId: id,
+      },
+    };
+    const state = callFooReducer(errorAction);
+
+    expect(fooSelectors.getFooErrorsById(state, { id })).toEqual(errors);
+  });
+
+  it('determines if the collection is fetching with getAre*EntitiesFetching', () => {
+    const collectionFetchAction = {
+      type: `${FETCH}_${resource}_${START}`,
+      // No meta.referenceId to specify specific entity fetch
+    };
+    const state = callFooReducer(collectionFetchAction);
+
+    expect(fooSelectors.getAreFooEntitiesFetching(state)).toEqual(true);
+  });
+
+  it('determines if a single entity is being fetched with getIs*Fetching', () => {
+    const fetchAction = {
+      type: `${FETCH}_${resource}_${START}`,
+      meta: {
+        referenceId: id,
+      },
+    };
+    const state = callFooReducer(fetchAction);
+
+    expect(fooSelectors.getIsFooFetching(state, { id })).toEqual(true);
+  });
+
+  it('determines if a single entity is being updated with getIs*Updating', () => {
+    const updateAction = {
+      type: `${UPDATE}_${resource}_${START}`,
+      meta: {
+        referenceId: id,
+      },
+    };
+    const state = callFooReducer(updateAction);
+
+    expect(fooSelectors.getIsFooUpdating(state, { id })).toEqual(true);
+  });
+
+  it('determines if a single entity is being removed with getIs*Removing', () => {
+    const updateAction = {
+      type: `${REMOVE}_${resource}_${START}`,
+      meta: {
+        referenceId: id,
+      },
+    };
+    const state = callFooReducer(updateAction);
+
+    expect(fooSelectors.getIsFooRemoving(state, { id })).toEqual(true);
+  });
+});

--- a/src/selector-factories/base-selectors.spec.ts
+++ b/src/selector-factories/base-selectors.spec.ts
@@ -29,10 +29,13 @@ describe('selectorsFactory()', () => {
   };
   const fooSelectors = selectorsFactory({ entitiesPath, resource });
 
-  const makePendingAction = (type: string) => ({
-    type,
-    meta: { referenceId: id },
-  });
+  const makePendingStateFromAction = (type: string) => {
+    const pendingAction = {
+      type,
+      meta: { referenceId: id },
+    };
+    return callFooReducer(pendingAction);
+  };
 
   it('dynamically creates a base set of selectors', () => {
     [
@@ -109,25 +112,17 @@ describe('selectorsFactory()', () => {
   });
 
   it('determines if a single entity is being fetched with getIs*Fetching', () => {
-    const fetchAction = makePendingAction(`${FETCH}_${resource}_${START}`);
-    const state = callFooReducer(fetchAction);
-
+    const state = makePendingStateFromAction(`${FETCH}_${resource}_${START}`);
     expect(fooSelectors.getIsFooFetching(state, { id })).toEqual(true);
   });
 
   it('determines if a single entity is being updated with getIs*Updating', () => {
-    const updateAction = makePendingAction(`${UPDATE}_${resource}_${START}`);
-    const state = callFooReducer(updateAction);
-
+    const state = makePendingStateFromAction(`${UPDATE}_${resource}_${START}`);
     expect(fooSelectors.getIsFooUpdating(state, { id })).toEqual(true);
   });
 
   it('determines if a single entity is being removed with getIs*Removing', () => {
-    const removeupdateAction = makePendingAction(
-      `${REMOVE}_${resource}_${START}`
-    );
-    const state = callFooReducer(removeupdateAction);
-
+    const state = makePendingStateFromAction(`${REMOVE}_${resource}_${START}`);
     expect(fooSelectors.getIsFooRemoving(state, { id })).toEqual(true);
   });
 });

--- a/src/selector-factories/base-selectors.spec.ts
+++ b/src/selector-factories/base-selectors.spec.ts
@@ -29,6 +29,11 @@ describe('selectorsFactory()', () => {
   };
   const fooSelectors = selectorsFactory({ entitiesPath, resource });
 
+  const makePendingAction = (type: string) => ({
+    type,
+    meta: { referenceId: id },
+  });
+
   it('dynamically creates a base set of selectors', () => {
     [
       `getFooEntities`,
@@ -104,37 +109,24 @@ describe('selectorsFactory()', () => {
   });
 
   it('determines if a single entity is being fetched with getIs*Fetching', () => {
-    const fetchAction = {
-      type: `${FETCH}_${resource}_${START}`,
-      meta: {
-        referenceId: id,
-      },
-    };
+    const fetchAction = makePendingAction(`${FETCH}_${resource}_${START}`);
     const state = callFooReducer(fetchAction);
 
     expect(fooSelectors.getIsFooFetching(state, { id })).toEqual(true);
   });
 
   it('determines if a single entity is being updated with getIs*Updating', () => {
-    const updateAction = {
-      type: `${UPDATE}_${resource}_${START}`,
-      meta: {
-        referenceId: id,
-      },
-    };
+    const updateAction = makePendingAction(`${UPDATE}_${resource}_${START}`);
     const state = callFooReducer(updateAction);
 
     expect(fooSelectors.getIsFooUpdating(state, { id })).toEqual(true);
   });
 
   it('determines if a single entity is being removed with getIs*Removing', () => {
-    const updateAction = {
-      type: `${REMOVE}_${resource}_${START}`,
-      meta: {
-        referenceId: id,
-      },
-    };
-    const state = callFooReducer(updateAction);
+    const removeupdateAction = makePendingAction(
+      `${REMOVE}_${resource}_${START}`
+    );
+    const state = callFooReducer(removeupdateAction);
 
     expect(fooSelectors.getIsFooRemoving(state, { id })).toEqual(true);
   });

--- a/src/selector-factories/base-selectors.ts
+++ b/src/selector-factories/base-selectors.ts
@@ -1,0 +1,80 @@
+import camelCase from 'lodash.camelcase';
+import capitalize from 'lodash.capitalize';
+import { createSelector } from 'reselect';
+import { ReduxSliceState } from './../reducer-factories/type-definitions';
+
+const pascalize = (string: string) => capitalize(camelCase(string));
+
+export type SelectorsFactoryConfig = {
+  entitiesPath: string;
+  resource: string;
+};
+type State = {
+  [resource_name: string]: any;
+};
+type Options = {
+  id: string;
+};
+export type SelectorFns = {
+  [selector_name: string]: Function;
+};
+
+function selectorsFactory({
+  entitiesPath,
+  resource,
+}: SelectorsFactoryConfig): SelectorFns {
+  const resourceName = pascalize(resource);
+
+  const getEntities = (state: State) => state[resource][entitiesPath];
+  const getId = (_state: State, { id }: Options) => id;
+
+  const getEntityById = createSelector(
+    getEntities,
+    getId,
+    (entities, id) => entities[id]
+  );
+
+  const getFirstEntity = createSelector(getEntities, entities => {
+    const firstKey = Object.keys(entities)[0];
+    return entities[firstKey];
+  });
+
+  const getSliceErrors = (state: ReduxSliceState) => state[resource].errors;
+
+  const getEntityErrorsById = createSelector(
+    getEntityById,
+    entity => entity.errors
+  );
+
+  const areEntitiesFetching = (state: ReduxSliceState) =>
+    !!state[resource].isFetching;
+
+  const isEntityFetching = createSelector(
+    getEntityById,
+    entity => !!entity.isFetching
+  );
+
+  const isEntityUpdating = createSelector(
+    getEntityById,
+    entity => !!entity.isUpdating
+  );
+
+  const isEntityRemoving = createSelector(
+    getEntityById,
+    entity => !!entity.isRemoving
+  );
+
+  return {
+    [`get${resourceName}Entities`]: getEntities,
+    [`get${resourceName}ById`]: getEntityById,
+    [`getCurrent${resourceName}`]: getFirstEntity,
+    [`get${resourceName}Errors`]: getSliceErrors,
+    [`get${resourceName}ErrorsById`]: getEntityErrorsById,
+    [`getAre${resourceName}EntitiesFetching`]: areEntitiesFetching,
+    [`getIs${resourceName}Fetching`]: isEntityFetching,
+    [`getIs${resourceName}Updating`]: isEntityUpdating,
+    [`getIs${resourceName}Removing`]: isEntityRemoving,
+  };
+}
+
+export default selectorsFactory;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3329,7 +3329,7 @@ requireindex@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
 
-reselect@*:
+reselect@*, reselect@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,6 +20,18 @@
   version "22.2.3"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-22.2.3.tgz#0157c0316dc3722c43a7b71de3fdf3acbccef10d"
 
+"@types/lodash.camelcase@^4.3.3":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@types/lodash.camelcase/-/lodash.camelcase-4.3.3.tgz#ea5fcc4badea2259008df74425cf80d4536385fc"
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash.capitalize@^4.2.3":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/@types/lodash.capitalize/-/lodash.capitalize-4.2.3.tgz#3a91ad84742974897cfe0b455d6abb5cc7ddf416"
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash.clonedeep@^4.5.3":
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.3.tgz#d42cfba3d929a4e1177a775142ce2a9444e384cf"
@@ -59,6 +71,12 @@
 "@types/lodash@*":
   version "4.14.108"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.108.tgz#02656af3add2e5b3174f830862c47421c00ef817"
+
+"@types/reselect@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@types/reselect/-/reselect-2.2.0.tgz#c667206cfdc38190e1d379babe08865b2288575f"
+  dependencies:
+    reselect "*"
 
 abab@^1.0.4:
   version "1.0.4"
@@ -2500,6 +2518,14 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+
+lodash.capitalize@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz#f826c9b4e2a8511d84e3aca29db05e1a4f3b72a9"
+
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
@@ -3302,6 +3328,10 @@ require-uncached@^1.0.3:
 requireindex@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
+
+reselect@*:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Context
If we have a consistent namespace within a `resource` where we store data entities (`entitiesPath`), and we consistently know where properties are going to be set, updated, or removed, then we can dynamically create selectors that traverse the structures that our reducers consistently output.

As an example, we actually use the `makeResourceReducer` function in our tests, use the same `resource` and `entitiesPath` for both reducer and selector factories, and are able to use the selectors on the output state from the `fooReducer`.

This is valuable as selectors traverse the exact states that reducers output, so by that relationship they have to be coupled. This allows data providers to only interface with selectors, which completely isolates the view from needing to know what the structure of the store looks like.

Note for the future, this can probably be its own package if consumers do not want to use selectors.

## Additional Changes
- Add `reselect`, `lodash.camelcase`, `lodash.capitalize`, and their respective `@types` files.
- Fix types on `makeResourceReducer` to be more usable

## Tasks

* [x] Unit tests added
