### PR TITLE
Api redux-thunk factory

### DIFF
--- a/src/actions/__snapshots__/actions.spec.ts.snap
+++ b/src/actions/__snapshots__/actions.spec.ts.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`resourceApiActionTypesFactory() creates baseApiActionTypes for a passed in resource 1`] = `
+Object {
+  "CREATE": "CREATE__foo",
+  "FETCH": "FETCH__foo",
+  "REMOVE": "REMOVE__foo",
+  "UPDATE": "UPDATE__foo",
+}
+`;

--- a/src/actions/actions.spec.ts
+++ b/src/actions/actions.spec.ts
@@ -1,5 +1,6 @@
 import API_LIFECYCLE_SUFFIXES from './api-lifecycle-suffixes';
 import isValidActionType from './is-valid-action-type';
+import { resourceApiActionTypesFactory } from './api-action-prefixes';
 
 describe('isValidActionType()', () => {
   const reducerNameSpace = 'FETCH_';
@@ -19,5 +20,11 @@ describe('isValidActionType()', () => {
       const actionType = `${reducerNameSpace}_foo_${suffix}`;
       expect(isValidActionType(reducerNameSpace, actionType)).toEqual(true);
     });
+  });
+});
+
+describe('resourceApiActionTypesFactory()', () => {
+  it('creates baseApiActionTypes for a passed in resource', () => {
+    expect(resourceApiActionTypesFactory('foo')).toMatchSnapshot();
   });
 });

--- a/src/actions/api-action-prefixes.ts
+++ b/src/actions/api-action-prefixes.ts
@@ -12,4 +12,13 @@ const API_ACTION_PREFIXES: ApiActionPrefixes = {
   REMOVE: 'REMOVE_',
 };
 
+export function resourceApiActionTypesFactory(resource: string) {
+  return {
+    FETCH: `${API_ACTION_PREFIXES.FETCH}_${resource}`,
+    CREATE: `${API_ACTION_PREFIXES.CREATE}_${resource}`,
+    UPDATE: `${API_ACTION_PREFIXES.UPDATE}_${resource}`,
+    REMOVE: `${API_ACTION_PREFIXES.REMOVE}_${resource}`,
+  };
+}
+
 export default API_ACTION_PREFIXES;

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,4 +1,5 @@
 export { default as API_LIFECYCLE_SUFFIXES } from './api-lifecycle-suffixes';
+export { resourceApiActionTypesFactory } from './api-action-prefixes';
 export { default as API_ACTION_PREFIXES } from './api-action-prefixes';
 export { default as isValidActionType } from './is-valid-action-type';
 export * from './type-definitions';

--- a/src/api-thunk-factory/__snapshots__/api-thunk.spec.ts.snap
+++ b/src/api-thunk-factory/__snapshots__/api-thunk.spec.ts.snap
@@ -1,0 +1,93 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`apiThunk() failed networkRequest responses dispatches the *__START and *__ERROR actions 1`] = `
+Array [
+  Array [
+    Object {
+      "meta": undefined,
+      "type": "FETCH__foo__START",
+    },
+  ],
+  Array [
+    Object {
+      "errors": Object {
+        "status": 500,
+        "statusText": "Internal server error",
+      },
+      "meta": undefined,
+      "type": "FETCH__foo__FAILURE",
+    },
+  ],
+]
+`;
+
+exports[`apiThunk() failed networkRequest responses dispatches the actions with meta attributes 1`] = `
+Array [
+  Array [
+    Object {
+      "meta": Object {
+        "referenceId": "123",
+      },
+      "type": "FETCH__foo__START",
+    },
+  ],
+  Array [
+    Object {
+      "errors": Object {
+        "status": 500,
+        "statusText": "Internal server error",
+      },
+      "meta": Object {
+        "referenceId": "123",
+      },
+      "type": "FETCH__foo__FAILURE",
+    },
+  ],
+]
+`;
+
+exports[`apiThunk() successful networkRequest responses dispatches the *__START and *__SUCCESS actions 1`] = `
+Array [
+  Array [
+    Object {
+      "meta": undefined,
+      "type": "FETCH__foo__START",
+    },
+  ],
+  Array [
+    Object {
+      "meta": undefined,
+      "payload": Object {
+        "id": "123",
+        "name": "foo",
+      },
+      "type": "FETCH__foo__SUCCESS",
+    },
+  ],
+]
+`;
+
+exports[`apiThunk() successful networkRequest responses dispatches the actions with meta attributes 1`] = `
+Array [
+  Array [
+    Object {
+      "meta": Object {
+        "referenceId": "123",
+      },
+      "type": "FETCH__foo__START",
+    },
+  ],
+  Array [
+    Object {
+      "meta": Object {
+        "referenceId": "123",
+      },
+      "payload": Object {
+        "id": "123",
+        "name": "foo",
+      },
+      "type": "FETCH__foo__SUCCESS",
+    },
+  ],
+]
+`;

--- a/src/api-thunk-factory/api-thunk.spec.ts
+++ b/src/api-thunk-factory/api-thunk.spec.ts
@@ -1,0 +1,109 @@
+import apiThunk from './api-thunk';
+import { resourceApiActionTypesFactory } from '../actions';
+
+describe('apiThunk()', () => {
+  const mockResponse = {
+    id: '123',
+    name: 'foo',
+  };
+  const dispatchFn = jest.fn();
+  const fooApiActions = resourceApiActionTypesFactory('foo');
+  const baseActionType = fooApiActions.FETCH;
+  const networkRequest = jest
+    .fn()
+    .mockReturnValue(Promise.resolve(mockResponse));
+  const defaultProps = {
+    baseActionType,
+    networkRequest,
+  };
+
+  const createApiThunkAndInvoke = (thunkProps: object = {}) => {
+    const actionCreator = apiThunk({ ...defaultProps, ...thunkProps });
+    return actionCreator(dispatchFn);
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('successful networkRequest responses', () => {
+    it('dispatches the *__START and *__SUCCESS actions', async () => {
+      await createApiThunkAndInvoke();
+      expect(dispatchFn.mock.calls).toMatchSnapshot();
+    });
+
+    it('dispatches the actions with meta attributes', async () => {
+      const meta = { referenceId: '123' };
+      await createApiThunkAndInvoke({ meta });
+      expect(dispatchFn.mock.calls).toMatchSnapshot();
+    });
+
+    it('uses the successNormalizer to parse the response for the action.payload', async () => {
+      const successNormalizer = (mockResp: object) => ({
+        ...mockResponse,
+        added: 'from success normalizer',
+      });
+      const normalizedResp = await createApiThunkAndInvoke({
+        successNormalizer,
+      });
+
+      expect(normalizedResp).toEqual({
+        ...mockResponse,
+        added: 'from success normalizer',
+      });
+    });
+
+    it('returns a Promise-y value that also can be chained off of', () => {
+      return createApiThunkAndInvoke().then((resp: any) => {
+        expect(resp).toEqual(mockResponse);
+      });
+    });
+  });
+
+  describe('failed networkRequest responses', () => {
+    const mockFailureResponse = {
+      status: 500,
+      statusText: 'Internal server error',
+    };
+
+    beforeAll(() => {
+      networkRequest.mockRejectedValue(mockFailureResponse);
+    });
+
+    it('dispatches the *__START and *__ERROR actions', async () => {
+      try {
+        await createApiThunkAndInvoke();
+      } catch (error) {
+        expect(dispatchFn.mock.calls).toMatchSnapshot();
+      }
+    });
+
+    it('dispatches the actions with meta attributes', async () => {
+      try {
+        const meta = { referenceId: '123' };
+        await createApiThunkAndInvoke({ meta });
+      } catch (error) {
+        expect(dispatchFn.mock.calls).toMatchSnapshot();
+      }
+    });
+
+    it('uses the failureNormalizer to parse the response for the action.errors', async () => {
+      try {
+        const failureNormalizer = (mockResp: any) => [mockResp.statusText];
+        await createApiThunkAndInvoke({ failureNormalizer });
+      } catch (error) {
+        expect(dispatchFn).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            errors: [mockFailureResponse.statusText],
+          })
+        );
+      }
+    });
+
+    it('returns a Promise-y value that also can be chained off of', () => {
+      return createApiThunkAndInvoke().catch((error: any) => {
+        expect(error).toEqual(mockFailureResponse);
+      });
+    });
+  });
+});

--- a/src/api-thunk-factory/api-thunk.ts
+++ b/src/api-thunk-factory/api-thunk.ts
@@ -1,0 +1,53 @@
+import { API_LIFECYCLE_SUFFIXES } from '../actions';
+
+const { START, FAILURE, SUCCESS } = API_LIFECYCLE_SUFFIXES;
+
+const noNormalization = (data: any) => data;
+
+export type apiThunkConfig = {
+  baseActionType: string;
+  failureNormalizer?: Function;
+  meta?: object;
+  networkRequest: Function;
+  successNormalizer?: Function;
+};
+
+function apiThunk({
+  baseActionType,
+  failureNormalizer = noNormalization,
+  meta,
+  networkRequest,
+  successNormalizer = noNormalization,
+}: apiThunkConfig): Function {
+  return async (dispatch: Function) => {
+    dispatch({
+      type: `${baseActionType}_${START}`,
+      meta,
+    });
+
+    try {
+      const response = await networkRequest();
+      const normalizedResponse = successNormalizer(response);
+
+      dispatch({
+        type: `${baseActionType}_${SUCCESS}`,
+        payload: normalizedResponse,
+        meta,
+      });
+
+      return normalizedResponse;
+    } catch (error) {
+      const normalizedErrors = failureNormalizer(error);
+
+      dispatch({
+        type: `${baseActionType}_${FAILURE}`,
+        errors: normalizedErrors,
+        meta,
+      });
+
+      throw error;
+    }
+  };
+}
+
+export default apiThunk;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import apiThunk from './api-thunk-factory/api-thunk';
 import defaultReducerFactories from './reducer-factories/default-factories';
 import resourceReducerFactory from './reducer-factories/resource-reducer-factory';
 import selectorsFactory from './selector-factories/base-selectors';
@@ -12,9 +13,7 @@ type MakeResourceReducerConfig = {
   resource: string;
 };
 
-export const makeResourceReducer = (
-  config: MakeResourceReducerConfig
-): Function =>
+const makeResourceReducer = (config: MakeResourceReducerConfig): Function =>
   resourceReducerFactory({
     defaultReducerFactories,
     entitiesPath,
@@ -25,7 +24,14 @@ type MakeResourceSelectorsConfig = {
   entitiesPath: string;
   resource: string;
 };
-export const makeResourceSelectors = (config: MakeResourceSelectorsConfig) =>
+
+const makeResourceSelectors = (config: MakeResourceSelectorsConfig) =>
   selectorsFactory({ entitiesPath, ...config });
 
-export { resourceReducerFactory, selectorsFactory };
+export {
+  apiThunk,
+  makeResourceReducer,
+  makeResourceSelectors,
+  resourceReducerFactory,
+  selectorsFactory,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import apiThunk from './api-thunk-factory/api-thunk';
 import defaultReducerFactories from './reducer-factories/default-factories';
 import resourceReducerFactory from './reducer-factories/resource-reducer-factory';
 import selectorsFactory from './selector-factories/base-selectors';
+import { resourceApiActionTypesFactory } from './actions';
 import { DefaultReducerFactories } from './reducer-factories/type-definitions';
 
 const entitiesPath = 'byId';
@@ -32,6 +33,7 @@ export {
   apiThunk,
   makeResourceReducer,
   makeResourceSelectors,
+  resourceApiActionTypesFactory,
   resourceReducerFactory,
   selectorsFactory,
 };


### PR DESCRIPTION
## Context
Adds a light wrapper higher order function that will dispatch all actions of an API life cycle, that are immediately recognized by reducers created through `resourceReducerFactory`.

In general, all API requests follow the general pattern of:
1. start the request
2. API responds, handle the success
  or
3. API responds, handle the error

As noted in the redux docs: https://redux.js.org/advanced/async-actions

## Additional Changes
- Make exports more consistent in the src/index.ts
- Add function for creating base API action types given a resource, `resourceApiActionTypesFactory`
- Expose the above function as well

## Tasks

* [x] Unit tests added
