### PR TITLE
fix (base selectors): Add existence check for getIs*ing non-existent entities

### DIFF
--- a/src/selector-factories/base-selectors.spec.ts
+++ b/src/selector-factories/base-selectors.spec.ts
@@ -116,6 +116,13 @@ describe('selectorsFactory()', () => {
     expect(fooSelectors.getIsFooFetching(state, { id })).toEqual(true);
   });
 
+  it("returns undefined if the single entity doesn't exist when getIs*ing", () => {
+    const state = callFooReducer({ type: '@@INIT' });
+    expect(fooSelectors.getIsFooFetching(state, { id: '890' })).toEqual(
+      undefined
+    );
+  });
+
   it('determines if a single entity is being updated with getIs*Updating', () => {
     const state = makePendingStateFromAction(`${UPDATE}_${resource}_${START}`);
     expect(fooSelectors.getIsFooUpdating(state, { id })).toEqual(true);

--- a/src/selector-factories/base-selectors.ts
+++ b/src/selector-factories/base-selectors.ts
@@ -51,17 +51,17 @@ function selectorsFactory({
 
   const isEntityFetching = createSelector(
     getEntityById,
-    entity => !!entity.isFetching
+    entity => entity && !!entity.isFetching
   );
 
   const isEntityUpdating = createSelector(
     getEntityById,
-    entity => !!entity.isUpdating
+    entity => entity && !!entity.isUpdating
   );
 
   const isEntityRemoving = createSelector(
     getEntityById,
-    entity => !!entity.isRemoving
+    entity => entity && !!entity.isRemoving
   );
 
   return {


### PR DESCRIPTION
## Context
The `getIs*ing` base selectors would error if the single entity in question didn't exist. This adds an existence check, and returns `undefined` if the `entity` is undefined

## Additional Changes
- Add `entity &&` existence check so that `!!entity.is*` wont cause errors for calling a property of `undefined` or `null`
- Add spec

## Tasks

* [x] Unit tests added
