### PR TITLE
fix: add existence check inside get*ErrorsById

### DIFF
--- a/src/selector-factories/base-selectors.spec.ts
+++ b/src/selector-factories/base-selectors.spec.ts
@@ -29,6 +29,7 @@ describe('selectorsFactory()', () => {
   };
   const fooSelectors = selectorsFactory({ entitiesPath, resource });
 
+  const makeBlankInitialState = () => callFooReducer({ type: '@@INIT' });
   const makePendingStateFromAction = (type: string) => {
     const pendingAction = {
       type,
@@ -54,7 +55,7 @@ describe('selectorsFactory()', () => {
   });
 
   it('gets all entities with get*Entities()', () => {
-    const state = callFooReducer({ type: '@@INIT' });
+    const state = makeBlankInitialState();
 
     expect(fooSelectors.getFooEntities(state)).toEqual(
       initialState[entitiesPath]
@@ -62,14 +63,16 @@ describe('selectorsFactory()', () => {
   });
 
   it('gets a specific entity with get*EntityById', () => {
-    const state = callFooReducer({ type: '@@INIT' });
+    const state = makeBlankInitialState();
+
     expect(fooSelectors.getFooById(state, { id })).toEqual(
       initialState[entitiesPath][id]
     );
   });
 
   it('gets the first entity with getCurrent*', () => {
-    const state = callFooReducer({ type: '@@INIT' });
+    const state = makeBlankInitialState();
+
     expect(fooSelectors.getCurrentFoo(state)).toEqual(
       initialState[entitiesPath]['123']
     );
@@ -102,7 +105,7 @@ describe('selectorsFactory()', () => {
   });
 
   it("doesn't error if the single entity doesn't exist in get*ErrorsById", () => {
-    const state = callFooReducer({ type: '@@INIT' });
+    const state = makeBlankInitialState();
 
     expect(fooSelectors.getFooErrorsById(state, { id: '890' })).toEqual(
       undefined
@@ -125,7 +128,8 @@ describe('selectorsFactory()', () => {
   });
 
   it("doesn't error if the single entity doesn't exist in getIs*ing", () => {
-    const state = callFooReducer({ type: '@@INIT' });
+    const state = makeBlankInitialState();
+
     expect(fooSelectors.getIsFooFetching(state, { id: '890' })).toEqual(
       undefined
     );

--- a/src/selector-factories/base-selectors.spec.ts
+++ b/src/selector-factories/base-selectors.spec.ts
@@ -101,6 +101,14 @@ describe('selectorsFactory()', () => {
     expect(fooSelectors.getFooErrorsById(state, { id })).toEqual(errors);
   });
 
+  it("doesn't error if the single entity doesn't exist in get*ErrorsById", () => {
+    const state = callFooReducer({ type: '@@INIT' });
+
+    expect(fooSelectors.getFooErrorsById(state, { id: '890' })).toEqual(
+      undefined
+    );
+  });
+
   it('determines if the collection is fetching with getAre*EntitiesFetching', () => {
     const collectionFetchAction = {
       type: `${FETCH}_${resource}_${START}`,
@@ -116,7 +124,7 @@ describe('selectorsFactory()', () => {
     expect(fooSelectors.getIsFooFetching(state, { id })).toEqual(true);
   });
 
-  it("returns undefined if the single entity doesn't exist when getIs*ing", () => {
+  it("doesn't error if the single entity doesn't exist in getIs*ing", () => {
     const state = callFooReducer({ type: '@@INIT' });
     expect(fooSelectors.getIsFooFetching(state, { id: '890' })).toEqual(
       undefined

--- a/src/selector-factories/base-selectors.ts
+++ b/src/selector-factories/base-selectors.ts
@@ -41,13 +41,13 @@ function selectorsFactory({
 
   const getSliceErrors = (state: ReduxSliceState) => state[resource].errors;
 
-  const getEntityErrorsById = createSelector(
-    getEntityById,
-    entity => entity.errors
-  );
-
   const areEntitiesFetching = (state: ReduxSliceState) =>
     !!state[resource].isFetching;
+
+  const getEntityErrorsById = createSelector(
+    getEntityById,
+    entity => entity && entity.errors
+  );
 
   const isEntityFetching = createSelector(
     getEntityById,


### PR DESCRIPTION
**Fixes:** https://github.com/ahoym/redesert/issues/25

## Context
If an app using `redesert` tries to use `get*ErrorsById` and the entity doesn't exist, it will throw an error. This is because of not being able to call a property of `undefined` or `null`.

## Changes
- Add existence check before trying to access errors
- Add specs
- Also move functions around so that all the entity accessing selectors are in the same logic block. Hopefully this will increase the chance (even if it's small) to make a developer notice it.

## Tasks

* [x] Unit tests added
